### PR TITLE
Add VPC outputs and RDS security group

### DIFF
--- a/terraform/environments/dev/security_groups.tf
+++ b/terraform/environments/dev/security_groups.tf
@@ -1,0 +1,26 @@
+resource "aws_security_group" "rds" {
+  name        = "darpo-${var.environment}-rds"
+  description = "Security group for RDS PostgreSQL"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "PostgreSQL from EKS"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    # We'll restrict this to the EKS cluster security group
+    security_groups = [module.eks.cluster_security_group_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "darpo-${var.environment}-rds"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.vpc.public_subnets
+}
+
+output "database_subnet_group" {
+  description = "ID of database subnet group"
+  value       = module.vpc.database_subnet_group
+}
+
+output "database_subnets" {
+  description = "List of IDs of database subnets"
+  value       = module.vpc.database_subnets
+}


### PR DESCRIPTION
## Description

This PR fixes the missing VPC outputs and adds the required RDS security group. These changes resolve the Terraform plan errors related to missing VPC attributes and undefined security group.

Changes include:

1. Added VPC module outputs:
   - vpc_id
   - private_subnets
   - public_subnets
   - database_subnet_group
   - database_subnets

2. Added RDS security group with:
   - PostgreSQL ingress from EKS cluster
   - All outbound traffic allowed
   - Proper environment tagging
   - VPC and EKS security group references

## Type of change

- [x] Bug fix (Missing VPC outputs)
- [x] Infrastructure improvement (RDS security)

## Impact and Dependencies

- **Impact Assessment:**
  - Service disruption: No
  - Security impact: Positive (proper security group configuration)
  - Dependencies: Requires EKS security group ID

## Testing Instructions

1. Run `terraform init` 
2. Run `terraform plan` to verify:
   - VPC outputs are available
   - Security group is properly configured
   - No missing resource errors

## Additional Notes

The security group configuration:
- Restricts PostgreSQL access to EKS cluster
- Follows AWS security best practices
- Can be easily modified for additional access if needed