### PR TITLE
Fix RDS PostgreSQL version to 15.4

### DIFF
--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -5,7 +5,7 @@ module "db" {
   identifier = "darpo-${var.environment}"
 
   engine                = "postgres"
-  engine_version        = "15.3"
+  engine_version        = "15.4"  # Updated to available version
   family                = "postgres15"
   major_engine_version  = "15"
   instance_class        = var.instance_class


### PR DESCRIPTION
## Description

This PR fixes the RDS creation error by updating the PostgreSQL version to 15.4, which is available in the ap-south-1 region.

### Changes:
- Updated `engine_version` from "15.3" to "15.4"
- Kept all other configurations same

## Type of change

- [x] Bug fix (RDS version compatibility)

## Impact and Dependencies

- **Impact Assessment:**
  - Service disruption: No
  - Database functionality: Same
  - Migration needed: No

## Testing Instructions

1. Run terraform plan to verify the version is accepted
```bash
cd terraform/environments/dev
terraform plan
```

## Additional Notes

The PostgreSQL 15.4 version includes all security patches and improvements from 15.3 and is the latest available version in ap-south-1 region.