### PR TITLE
Update EKS cluster version to 1.31

### DIFF
--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "~> 19.0"
 
   cluster_name                   = var.cluster_name
-  cluster_version                = "1.28"
+  cluster_version                = "1.31"
   cluster_endpoint_public_access = true
 
   vpc_id     = var.vpc_id


### PR DESCRIPTION
## Description

This PR updates the EKS cluster version from 1.28 to 1.31, which includes the latest features, security updates, and bug fixes.

### Changes:
- Updated `cluster_version` from "1.28" to "1.31" in the EKS module

## Type of change

- [x] Enhancement (EKS version upgrade)
- [x] Security improvement (latest version)

## Impact and Dependencies

- **Impact Assessment:**
  - Service disruption: Yes (requires cluster update)
  - Security impact: Positive (latest security patches)
  - Dependencies: None

## Testing Instructions

1. Review the version change
2. Test in dev environment first:
```bash
terraform plan -out=tfplan
terraform apply tfplan
```

## Additional Notes

- If updating an existing cluster, this will trigger a cluster upgrade
- Ensure application compatibility with Kubernetes 1.31
- Consider testing applications in dev environment first