### PR TITLE
Add AWS caller identity data source

### DIFF
--- a/terraform/modules/eks/data.tf
+++ b/terraform/modules/eks/data.tf
@@ -1,0 +1,13 @@
+# Get current AWS account information
+data "aws_caller_identity" "current" {}
+
+# Get EKS cluster auth data
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+  depends_on = [module.eks]
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+  depends_on = [module.eks]
+}


### PR DESCRIPTION
## Description

This PR adds required data sources for AWS caller identity and EKS cluster information. It fixes the error:

```
Error: Reference to undeclared resource
  A data resource "aws_caller_identity" "current" has not been declared in module.eks.
```

### Added Data Sources:

1. **AWS Caller Identity**:
```hcl
data "aws_caller_identity" "current" {}
```
- Used to get current AWS account ID
- Required for IAM role trust relationships

2. **EKS Cluster Data Sources**:
```hcl
data "aws_eks_cluster" "cluster" {}
data "aws_eks_cluster_auth" "cluster" {}
```
- Used to get cluster information
- Required for auth configmap updates

## Impact
- Fixes IAM role creation
- No changes to existing resources
- Required for GitHub Actions integration

## Testing Instructions

1. Apply changes:
```bash
terraform plan
```

2. Verify no errors related to aws_caller_identity