### PR TITLE
Add Kubernetes provider configuration

### DIFF
--- a/terraform/environments/dev/provider.tf
+++ b/terraform/environments/dev/provider.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+  depends_on = [module.eks]
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+  depends_on = [module.eks]
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}

--- a/terraform/modules/eks/versions.tf
+++ b/terraform/modules/eks/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the Kubernetes provider configuration to allow Terraform to interact with the EKS cluster for managing the `aws-auth` ConfigMap.

### Changes:

1. **Added Provider Requirements**:
```hcl
terraform {
  required_providers {
    kubernetes = {
      source  = "hashicorp/kubernetes"
      version = ">= 2.0.0"
    }
  }
}
```

2. **Added Kubernetes Provider Configuration**:
```hcl
provider "kubernetes" {
  host                   = data.aws_eks_cluster.cluster.endpoint
  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
  token                  = data.aws_eks_cluster_auth.cluster.token
}
```

3. **Added EKS Data Sources**:
- For getting cluster endpoint and auth token
- With proper dependencies

## Testing Instructions

1. Remove existing state for kubernetes resources:
```bash
terraform state rm module.eks.kubernetes_config_map_v1_data.aws_auth
```

2. Reinitialize Terraform:
```bash
terraform init
```

3. Apply changes:
```bash
terraform plan
terraform apply
```

## Notes
- This change is necessary for Terraform to manage Kubernetes resources
- The provider will use EKS authentication tokens
- Dependencies are properly managed to ensure EKS cluster exists before trying to access it