### PR TITLE
Add IAM role configuration for GitHub Actions

### DIFF
--- a/terraform/environments/dev/data.tf
+++ b/terraform/environments/dev/data.tf
@@ -1,0 +1,2 @@
+# Get current AWS account information
+data "aws_caller_identity" "current" {}

--- a/terraform/environments/dev/iam.tf
+++ b/terraform/environments/dev/iam.tf
@@ -1,0 +1,42 @@
+# IAM role for GitHub Actions
+resource "aws_iam_role" "github_actions" {
+  name = "darpo-${var.environment}-github-actions"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = "darpo"
+  }
+}
+
+# Policy for GitHub Actions role
+resource "aws_iam_role_policy" "github_actions" {
+  name = "darpo-${var.environment}-github-actions"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "eks:*",
+          "ecr:*"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## Description

This PR adds the missing IAM role configuration for GitHub Actions that was previously in the EKS module.

### Changes:

1. **Added IAM Role Configuration**:
```hcl
resource "aws_iam_role" "github_actions" {
  name = "darpo-${var.environment}-github-actions"
  # ... role configuration
}
```

2. **Added IAM Policy**:
```hcl
resource "aws_iam_role_policy" "github_actions" {
  name = "darpo-${var.environment}-github-actions"
  # ... policy configuration
}
```

3. **Added Data Source**:
```hcl
data "aws_caller_identity" "current" {}
```

### Organization:
- `iam.tf` for IAM-related resources
- `data.tf` for data sources
- Clean separation of concerns

## Testing Instructions

1. Run Terraform commands:
```bash
terraform init  # For data source
terraform plan
```

## Notes
- This completes the separation of concerns started in previous PRs
- IAM role is required for GitHub Actions authentication
- Proper environment-based naming