### PR TITLE
Fix Kubernetes provider configuration and DB username validation

### DIFF
--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -8,6 +8,10 @@ variable "db_username" {
   description = "Database administrator username"
   type        = string
   sensitive   = true
+  validation {
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9_]*$", var.db_username))
+    error_message = "The db_username must start with a letter and can contain only alphanumeric characters and underscores."
+  }
 }
 
 variable "environment" {

--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+  depends_on = [module.eks]
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+  depends_on = [module.eks]
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}


### PR DESCRIPTION
## Description

This PR fixes two issues:
1. Kubernetes provider configuration for aws-auth ConfigMap
2. DB username validation for RDS

### Changes:

1. **Kubernetes Provider Configuration**:
```hcl
provider "kubernetes" {
  host                   = data.aws_eks_cluster.cluster.endpoint
  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
  token                  = data.aws_eks_cluster_auth.cluster.token
}
```

2. **DB Username Validation**:
```hcl
variable "db_username" {
  # ...
  validation {
    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9_]*$", var.db_username))
    error_message = "The db_username must start with a letter and can contain only alphanumeric characters and underscores."
  }
}
```

## Testing Instructions

1. Set a valid DB username:
```bash
export TF_VAR_db_username="darpo_admin"
```

2. Run Terraform:
```bash
terraform init
terraform plan
```

## Notes
- Proper Kubernetes authentication for aws-auth ConfigMap
- Validation ensures RDS-compatible username format
- Clear dependency chain for EKS cluster